### PR TITLE
Initial API Route set up for stock searching and prediction

### DIFF
--- a/build/app.py
+++ b/build/app.py
@@ -1,7 +1,7 @@
 from flask import Flask, jsonify, render_template
 import yfinance as yf
 import numpy as np 
-
+import models
 
 
 app = Flask(__name__)
@@ -50,6 +50,8 @@ def predict_future_stock_price(model, ticker, period = "1y"):
     prices_data_y = stock_history['Close'].values
     values = len(prices_data_y)
     time_days_X = np.arange(values).reshape(-1, 1)
+
+    
 
     """
     The prices data and X (time) will be sent to our models python file and the model results will be returned

--- a/build/models.py
+++ b/build/models.py
@@ -1,0 +1,47 @@
+from sklearn.linear_model import LinearRegression
+from sklearn.model_selection import train_test_split
+import yfinance as yf
+import numpy as np 
+
+""" 
+This class is intended to take in the data and model information from the API call and upon training, 
+return the appropriate jsonified outcome. 
+
+"""
+class train_model:
+    def __init__(self, data, model, test_ratio = 0.2):
+        self.data = data
+        self.model = model
+        self.test_ratio = test_split
+
+    """
+    Splits the provided time series data for model training and testing
+
+    """
+
+    def generate_split_data(self):
+        X_train, X_test, y_train, y_test = train_test_split(X, y, test_size = self.test_ratio)
+
+        self.X_train = X_train
+        self.X_test = X_test 
+        self.y_train = y_train 
+        self.y_test = y_test
+
+    """
+    method for model training
+    """
+
+    def train_model(self):
+        self.model.fit(self.X_train, self.y_train)
+    
+    """
+    Return the model weights
+    """
+
+    def return_model_params(self):
+        return self.model.get_params()
+
+
+
+if __name__ == "__main__":
+    pass


### PR DESCRIPTION
I created 3 Initial Flask API routes and commented on their functionality. The search stock route is intended to accept a stock ticker and period, returning the history of the stock in json format. There is also another route to capture more information about the stock based on the stock ticker. Lastly, I created a route that was intended to accept a type of ML model, the stick ticker, and the period, providing a prediction of the stock for that set period in the future. The functionality of the model route and stock information route will be updated upon further team discussion, but this is a baseline. 